### PR TITLE
🐛 fix: vitest config 타입 에러 해결

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,10 @@
-/// <reference types="vitest" />
 import path from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
+import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
-export default defineConfig({
+const viteConfig = defineViteConfig({
   plugins: [react()],
 
   resolve: {
@@ -13,10 +12,14 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+});
 
+const vitestConfig = defineVitestConfig({
   test: {
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./__tests__/setup.ts'],
   },
 });
+
+export default mergeConfig(viteConfig, vitestConfig);


### PR DESCRIPTION
### 이슈 번호
close #1 

### 해결 방법
[스택오버플로우](https://stackoverflow.com/questions/72146352/vitest-defineconfig-test-does-not-exist-in-type-userconfigexport/73106019#73106019)의 게시글을 통해 해결했습니다.

### 소요 시간
0.5 시간