### PR TITLE
구글 챗 웹훅 연동 (워크플로우 파일 수정)

### DIFF
--- a/.github/workflows/pr-google-chat-alert.yml
+++ b/.github/workflows/pr-google-chat-alert.yml
@@ -1,0 +1,29 @@
+name: Deploy ## 21
+
+# 명시된 브랜치 목록들을 base branch로 하는 PR이 [생성, 재생성, head 브랜치 동기화, PR 리뷰 준비 완료] 이벤트 발생 시 워크플로우 동작
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [opened, reopened, synchronize, ready_for_review] # 해당 타입들은 github webhook payload 타입 목록을 따릅니다
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest # 워크플로우가 실행될 GitHub Actions 러너의 OS를 지정합니다.
+
+    steps:
+      - name: Notify Google Chat on Pull Request
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY="${{ github.event.pull_request.body }}"
+          PR_USER_ID="${{ github.event.pull_request.user.id }}"
+          PR_USER_LOGIN="${{ github.event.pull_request.user.login }}"
+
+          # GitHub Actions의 시간은 UTC로 제공되므로, Asia/Seoul로 변환
+          CURRENT_TIME_KST=$(TZ="Asia/Seoul" date '+%Y-%m-%d %H:%M:%S')
+
+          curl -X POST \
+          -H 'Content-Type: application/json' \
+          -d "{\"text\": \"🐬 [Platform-Monitoring]\n\n${PR_USER_LOGIN} 님이 Pull Request 를 생성하였습니다.\n\n- PR 제목: ${PR_TITLE}\n- PR 내용: ${PR_BODY}\n- 시각: ${CURRENT_TIME_KST}\"}" \
+          "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}"

--- a/.github/workflows/pr-google-chat-alert.yml
+++ b/.github/workflows/pr-google-chat-alert.yml
@@ -3,6 +3,9 @@ name: Deploy ## 21
 # 명시된 브랜치 목록들을 base branch로 하는 PR이 [생성, 재생성, head 브랜치 동기화, PR 리뷰 준비 완료] 이벤트 발생 시 워크플로우 동작
 on:
   pull_request:
+    branches:
+      - main
+      - develop
     types: [opened, reopened, synchronize, ready_for_review] # 해당 타입들은 github webhook payload 타입 목록을 따릅니다
 
 jobs:

--- a/.github/workflows/pr-google-chat-alert.yml
+++ b/.github/workflows/pr-google-chat-alert.yml
@@ -3,9 +3,6 @@ name: Deploy ## 21
 # 명시된 브랜치 목록들을 base branch로 하는 PR이 [생성, 재생성, head 브랜치 동기화, PR 리뷰 준비 완료] 이벤트 발생 시 워크플로우 동작
 on:
   pull_request:
-    branches:
-      - main
-      - develop
     types: [opened, reopened, synchronize, ready_for_review] # 해당 타입들은 github webhook payload 타입 목록을 따릅니다
 
 jobs:


### PR DESCRIPTION
### 이슈 번호

close #9 

### 작업 내용

PR 내용 중에 백틱(탭키 위에 있는 그거) 문자로 감싸진 문자열이 있으면 GitHub Actions 워크플로우 수행 과정에서 명령어로 인식할 수 있다고 하네요...
이게 사실이면 PR에 백틱은 넣지 못하거나 이스케이프 처리해야 할 것 같습니다.
여튼 수정해서 다시 올립니다!

### 스크린샷(선택)

![image](https://github.com/user-attachments/assets/4e4cae68-1c66-44ea-8813-5e795c7ebad4)
