### PR TITLE
💄 style: 레이아웃 수정

### DIFF
--- a/src/components/Aside/style/aside.ts
+++ b/src/components/Aside/style/aside.ts
@@ -6,7 +6,7 @@ export const S = {
     display: flex;
 
     flex: 1;
-
+    max-width: 26.2rem;
     border-left: ${({ theme, $position }) => $position === 'right' && `1px solid ${theme.colors.gray[200]}`};
     border-right: ${({ theme, $position }) => $position === 'left' && `1px solid ${theme.colors.gray[200]}`};
 

--- a/src/components/Layout/style/layout.ts
+++ b/src/components/Layout/style/layout.ts
@@ -15,7 +15,8 @@ export const S = {
 
   ContentContainer: styled.div`
     display: flex;
-    width: 120rem;
+    width: 100vw;
+    justify-content: center;
     min-height: calc(100dvh - 6.4rem);
     max-height: calc(100dvh - 6.4rem);
 


### PR DESCRIPTION
### 이슈 번호
#29 

### 작업 내용
레아이웃 양옆 빈여백 없애기 (스크롤바 페이지 오른쪽에 붙이기 위함)

### 스크린샷(선택)
![스크린샷 2024-12-16 10 00 28](https://github.com/user-attachments/assets/c2baab01-e1ee-4d95-b33d-40bca86ec91c)

### 리뷰 요구사항(선택)
