### PR TITLE
fix: Layout 콘텐츠 너비 문제 해결

### DIFF
--- a/src/components/Aside/style/aside.ts
+++ b/src/components/Aside/style/aside.ts
@@ -1,11 +1,13 @@
 import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';
 
+export const ASIDE_WIDTH = 27;
+
 export const S = {
   Aside: styled.aside<{ $position: string }>`
     display: flex;
 
-    flex: 1;
+    width: ${ASIDE_WIDTH}rem;
 
     border-left: ${({ theme, $position }) => $position === 'right' && `1px solid ${theme.colors.gray[200]}`};
     border-right: ${({ theme, $position }) => $position === 'left' && `1px solid ${theme.colors.gray[200]}`};
@@ -17,7 +19,7 @@ export const S = {
 
   Content: styled.div`
     display: flex;
-    flexdirection: column;
+    flex-direction: column;
 
     flex: 1;
     padding: 1.6rem;

--- a/src/components/Aside/style/aside.ts
+++ b/src/components/Aside/style/aside.ts
@@ -1,7 +1,7 @@
+import { ASIDE_WIDTH } from '@/constants/style';
+
 import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';
-
-export const ASIDE_WIDTH = 27;
 
 export const S = {
   Aside: styled.aside<{ $position: string }>`

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -2,6 +2,10 @@ import { PropsWithChildren } from 'react';
 
 import { S } from '@/components/Content/style';
 
-export default function Content({ children }: PropsWithChildren) {
-  return <S.Content>{children}</S.Content>;
+interface Props extends PropsWithChildren {
+  asideCount?: number;
+}
+
+export default function Content({ asideCount = 2, children }: Props) {
+  return <S.Content $asideCount={asideCount}>{children}</S.Content>;
 }

--- a/src/components/Content/style/content.ts
+++ b/src/components/Content/style/content.ts
@@ -1,4 +1,4 @@
-import { ASIDE_WIDTH } from '@/components/Aside/style/aside';
+import { ASIDE_WIDTH } from '@/constants/style';
 
 import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';

--- a/src/components/Content/style/content.ts
+++ b/src/components/Content/style/content.ts
@@ -1,9 +1,22 @@
+import { ASIDE_WIDTH } from '@/components/Aside/style/aside';
+
+import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';
 
-export const S = {
-  Content: styled.article({
-    width: '66rem',
+const DEFAULT_CONTENT_WIDTH = 66;
 
-    padding: '2.4rem',
-  }),
+const WIDTH: Record<number, string> = {
+  0: '100%',
+  1: `calc(${DEFAULT_CONTENT_WIDTH}rem + ${ASIDE_WIDTH}rem)`,
+  2: `${DEFAULT_CONTENT_WIDTH}rem`,
+};
+
+export const S = {
+  Content: styled.article<{ $asideCount: number }>`
+    width: ${({ $asideCount }) => WIDTH[$asideCount]};
+
+    @media (max-width: ${MEDIA_QUERY.DESKTOP_S}) {
+      width: 100%;
+    }
+  `,
 };

--- a/src/components/Layout/Header/style/header.ts
+++ b/src/components/Layout/Header/style/header.ts
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled';
+import { HEADER_HEIGHT } from '@/components/Layout/constants/style';
 
-export const HEADER_HIGHT = 6.4;
+import styled from '@emotion/styled';
 
 export const S = {
   Header: styled.header(({ theme }) => ({
@@ -8,7 +8,7 @@ export const S = {
     justifyContent: 'center',
 
     width: '100%',
-    height: `${HEADER_HIGHT}rem`,
+    height: `${HEADER_HEIGHT}rem`,
 
     borderBottom: `1px solid ${theme.colors.gray[200]}`,
   })),

--- a/src/components/Layout/Header/style/header.ts
+++ b/src/components/Layout/Header/style/header.ts
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 
+export const HEADER_HIGHT = 6.4;
+
 export const S = {
   Header: styled.header(({ theme }) => ({
     display: 'flex',
     justifyContent: 'center',
 
     width: '100%',
-    height: '6.4rem',
+    height: `${HEADER_HIGHT}rem`,
 
     borderBottom: `1px solid ${theme.colors.gray[200]}`,
   })),

--- a/src/components/Layout/constants/style.ts
+++ b/src/components/Layout/constants/style.ts
@@ -1,0 +1,1 @@
+export const HEADER_HEIGHT = 6.4;

--- a/src/components/Layout/style/layout.ts
+++ b/src/components/Layout/style/layout.ts
@@ -1,3 +1,5 @@
+import { HEADER_HIGHT } from '@/components/Layout/Header/style/header';
+
 import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';
 
@@ -9,15 +11,15 @@ export const S = {
 
     width: '100vw',
     height: '100vh',
-
-    backgroundColor: 'gray',
   }),
 
   ContentContainer: styled.div`
     display: flex;
-    width: 120rem;
-    min-height: calc(100dvh - 6.4rem);
-    max-height: calc(100dvh - 6.4rem);
+    justify-content: center;
+
+    width: 100%;
+    min-height: calc(100dvh - ${HEADER_HIGHT}rem);
+    max-height: calc(100dvh - ${HEADER_HIGHT}rem);
 
     overflow-y: auto;
     background-color: white;

--- a/src/components/Layout/style/layout.ts
+++ b/src/components/Layout/style/layout.ts
@@ -1,4 +1,4 @@
-import { HEADER_HIGHT } from '@/components/Layout/Header/style/header';
+import { HEADER_HEIGHT } from '@/components/Layout/constants/style';
 
 import { MEDIA_QUERY } from '@/constants';
 import styled from '@emotion/styled';
@@ -18,8 +18,8 @@ export const S = {
     justify-content: center;
 
     width: 100%;
-    min-height: calc(100dvh - ${HEADER_HIGHT}rem);
-    max-height: calc(100dvh - ${HEADER_HIGHT}rem);
+    min-height: calc(100dvh - ${HEADER_HEIGHT}rem);
+    max-height: calc(100dvh - ${HEADER_HEIGHT}rem);
 
     overflow-y: auto;
     background-color: white;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -2,3 +2,5 @@ export const MEDIA_QUERY = {
   DESKTOP_S: '767px',
   DESKTOP_M: '1200px',
 };
+
+export const ASIDE_WIDTH = 27;


### PR DESCRIPTION
### 이슈 번호
close #31

### 작업 내용
- 콘텐츠에 어사이드 갯수 받도록 수정
- 콘텐츠 내부 패딩 삭제
- 어사이드 너비 flex 1에서 27rem으로 수정

### 스크린샷(선택)
<img width="1280" alt="스크린샷 2024-12-16 오전 11 11 38" src="https://github.com/user-attachments/assets/ed67fb97-d493-4dc1-9c9b-c3acaaeca077" />
<img width="1280" alt="스크린샷 2024-12-16 오전 11 11 49" src="https://github.com/user-attachments/assets/25819ac0-2099-4f96-b4b3-df3abe403a0a" />

### 리뷰 요구사항(선택)
