### PR TITLE
공통 텍스트 필드 & 텍스트 에리어 컴포넌트 구현

### DIFF
--- a/src/components/Button/style/index.ts
+++ b/src/components/Button/style/index.ts
@@ -16,7 +16,7 @@ interface LoadingSpinnerStyleProps {
 }
 
 /** 버튼 사이즈 프로퍼티에 따른 너비 사이즈 리터럴 값 */
-const WIDTH = {
+const WIDTH: { [key in ButtonSize]: string } = {
   icon: '3.2rem',
   small: '6.4rem',
   medium: '9.6rem',

--- a/src/components/Button/style/index.ts
+++ b/src/components/Button/style/index.ts
@@ -115,6 +115,7 @@ export const S = {
     align-items: center;
     border-radius: 0.4rem;
     font-size: ${({ theme }) => theme.typography.body4};
+    outline: none;
     cursor: pointer;
     transition: all 0.15s;
 
@@ -128,9 +129,8 @@ export const S = {
     }}
 
     // 버튼 포커스 상태일 때 스타일
-    // TODO(성찬): 버튼 포커스 상태일 때 스타일이 안바뀌는 문제 수정
     &:focus {
-      outline: '2px solid ${({ theme }) => theme.colors.error[700]}';
+      box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.gray[700]};
     }
   `,
   /** 로딩 스피너 스타일 */

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren, TextareaHTMLAttributes } from 'react';
+
+import { S } from './style';
+
+interface Props extends PropsWithChildren<TextareaHTMLAttributes<HTMLTextAreaElement>> {
+  isError?: boolean;
+}
+
+/**
+ * 공통 텍스트 에리어 컴포넌트
+ */
+export default function TextArea({ isError = false, ...p }: Props) {
+  /** 텍스트 에리어 높이 자동 조절 */
+  const adjustHeight = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    const target = e.currentTarget;
+    target.style.height = 'auto';
+    target.style.height = `${target.scrollHeight + 4}px`;
+  };
+
+  return <S.TextArea {...p} $isError={isError} rows={p.rows ?? 1} onInput={adjustHeight} />;
+}

--- a/src/components/TextArea/stories/TextArea.stories.ts
+++ b/src/components/TextArea/stories/TextArea.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import TextArea from '..';
+
+const meta = {
+  component: TextArea,
+  tags: ['autodocs', '!dev'],
+  args: { placeholder: 'TextArea', isError: false, disabled: false, onKeyDown: fn(), onFocus: fn(), onBlur: fn() },
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const DefaultTextArea: Story = {
+  args: {
+    placeholder: 'TextArea',
+  },
+};
+
+export const MultiRowTextArea: Story = {
+  args: {
+    placeholder: '3 Rows',
+    rows: 3,
+  },
+};
+
+export const DisabledTextArea: Story = {
+  args: {
+    placeholder: 'Disabled',
+    disabled: true,
+  },
+};
+
+export const ErrorTextArea: Story = {
+  args: {
+    placeholder: 'Error',
+    isError: true,
+  },
+};

--- a/src/components/TextArea/style/index.ts
+++ b/src/components/TextArea/style/index.ts
@@ -20,6 +20,7 @@ export const S = {
 
     // 폰트 스타일
     ${({ theme }) => theme.typography.body1}
+    color: ${({ theme }) => theme.colors.gray[900]};
 
     // 배경 및 테두리 스타일
     background-color: ${({ theme }) => theme.colors.white};
@@ -42,7 +43,7 @@ export const S = {
     &:disabled {
       background-color: ${({ theme }) => theme.colors.gray[100]};
       border: 2px solid ${({ theme }) => theme.colors.gray[200]};
-      color: ${({ theme }) => theme.colors.gray[200]};
+      color: ${({ theme }) => theme.colors.gray[400]};
       cursor: not-allowed;
     }
     &:disabled:hover {

--- a/src/components/TextArea/style/index.ts
+++ b/src/components/TextArea/style/index.ts
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+interface TextAreaStyleProps {
+  $isError: boolean;
+}
+
+export const S = {
+  /** 공통 텍스트 에리어 컴포넌트 스타일 */
+  TextArea: styled.textarea<TextAreaStyleProps>`
+    width: 100%;
+    padding: 0.6rem 1.2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.4rem;
+    outline: none;
+    resize: none;
+    overflow: hidden;
+    transition: all 0.15s;
+
+    // 폰트 스타일
+    ${({ theme }) => theme.typography.body1}
+
+    // 배경 및 테두리 스타일
+    background-color: ${({ theme }) => theme.colors.white};
+    border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.gray[300])};
+
+    // 텍스트 에리어 상태에 따른 스타일
+    &::placeholder {
+      color: ${({ theme }) => theme.colors.gray[400]};
+    }
+    &:hover {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.gray[500])};
+    }
+    &:active,
+    &:focus {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.primary[500])};
+    }
+    &:focus:hover {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.primary[500])};
+    }
+    &:disabled {
+      background-color: ${({ theme }) => theme.colors.gray[100]};
+      border: 2px solid ${({ theme }) => theme.colors.gray[200]};
+      color: ${({ theme }) => theme.colors.gray[200]};
+      cursor: not-allowed;
+    }
+    &:disabled:hover {
+      border: 2px solid ${({ theme }) => theme.colors.gray[200]};
+    }
+    &:disabled::placeholder {
+      color: ${({ theme }) => theme.colors.gray[200]};
+    }
+  `,
+};

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -1,0 +1,15 @@
+import { InputHTMLAttributes, PropsWithChildren } from 'react';
+
+import { S } from './style';
+
+interface Props extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
+  heightSize?: 'small' | 'medium' | 'large';
+  isError?: boolean;
+}
+
+/**
+ * 공통 텍스트 필드 컴포넌트
+ */
+export default function TextField({ heightSize = 'medium', isError = false, ...p }: Props) {
+  return <S.TextField {...p} $heightSize={heightSize} $isError={isError} />;
+}

--- a/src/components/TextField/stories/TextField.stories.ts
+++ b/src/components/TextField/stories/TextField.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import TextField from '..';
+
+const meta = {
+  component: TextField,
+  tags: ['autodocs', '!dev'],
+  args: { heightSize: 'medium', placeholder: 'TextField', isError: false, onKeyDown: fn(), onFocus: fn(), onBlur: fn() },
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MediumTextField: Story = {
+  args: {
+    heightSize: 'medium',
+    placeholder: 'Medium',
+  },
+};
+
+export const SmallDisabledTextField: Story = {
+  args: {
+    heightSize: 'small',
+    placeholder: 'Placeholder',
+    disabled: true,
+  },
+};
+
+export const LargeErrorTextField: Story = {
+  args: {
+    heightSize: 'large',
+    placeholder: 'Error',
+    isError: true,
+  },
+};

--- a/src/components/TextField/stories/TextField.stories.ts
+++ b/src/components/TextField/stories/TextField.stories.ts
@@ -6,7 +6,7 @@ import TextField from '..';
 const meta = {
   component: TextField,
   tags: ['autodocs', '!dev'],
-  args: { heightSize: 'medium', placeholder: 'TextField', isError: false, onKeyDown: fn(), onFocus: fn(), onBlur: fn() },
+  args: { heightSize: 'medium', placeholder: 'TextField', isError: false, disabled: false, onKeyDown: fn(), onFocus: fn(), onBlur: fn() },
 } satisfies Meta<typeof TextField>;
 
 export default meta;

--- a/src/components/TextField/style/index.ts
+++ b/src/components/TextField/style/index.ts
@@ -1,0 +1,71 @@
+import { Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { TextFieldHeightSize } from '../types';
+
+interface TextFieldStyleProps {
+  $heightSize: TextFieldHeightSize;
+  $isError: boolean;
+}
+
+/** 텍스트 필드의 높이 사이즈 프로퍼티에 따른 리터럴 값 */
+const HEIGHT: { [key in TextFieldHeightSize]: string } = {
+  small: '3.2rem',
+  medium: '4rem',
+  large: '4.4rem',
+};
+
+const getFontSize = (theme: Theme, heightSize: TextFieldHeightSize) => {
+  if (heightSize === 'small') return theme.typography.body3;
+  else if (heightSize === 'medium') return theme.typography.body1;
+  else return theme.typography.subtitle;
+};
+
+export const S = {
+  /** 공통 텍스트 필드 컴포넌트 스타일 */
+  TextField: styled.input<TextFieldStyleProps>`
+    width: '100%';
+    height: ${({ $heightSize }) => HEIGHT[$heightSize]};
+    padding: 0.8rem 1.2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.4rem;
+    outline: none;
+    transition: all 0.15s;
+
+    // 폰트 스타일
+    ${({ theme, $heightSize }) => getFontSize(theme, $heightSize)}
+
+    // 배경 및 테두리 스타일
+    background-color: ${({ theme }) => theme.colors.white};
+    border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.gray[300])};
+
+    // 텍스트 필드 상태에 따른 스타일
+    &::placeholder {
+      color: ${({ theme }) => theme.colors.gray[400]};
+    }
+    &:hover {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.gray[500])};
+    }
+    &:active,
+    &:focus {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.primary[500])};
+    }
+    &:focus:hover {
+      border: 2px solid ${({ theme, $isError }) => ($isError ? theme.colors.error[500] : theme.colors.primary[500])};
+    }
+    &:disabled {
+      background-color: ${({ theme }) => theme.colors.gray[100]};
+      border: 2px solid ${({ theme }) => theme.colors.gray[200]};
+      color: ${({ theme }) => theme.colors.gray[200]};
+      cursor: not-allowed;
+    }
+    &:disabled:hover {
+      border: 2px solid ${({ theme }) => theme.colors.gray[200]};
+    }
+    &:disabled::placeholder {
+      color: ${({ theme }) => theme.colors.gray[200]};
+    }
+  `,
+};

--- a/src/components/TextField/style/index.ts
+++ b/src/components/TextField/style/index.ts
@@ -15,6 +15,12 @@ const HEIGHT: { [key in TextFieldHeightSize]: string } = {
   large: '4.4rem',
 };
 
+/**
+ * 공통 텍스트 필드의 폰트 스타일을 반환하는 함수
+ * @param theme 전역 테마 객체 (색상만 사용)
+ * @param heightSize 높이 사이즈 프로퍼티
+ * @returns `heightSize`에 따른 폰트 스타일
+ */
 const getFontSize = (theme: Theme, heightSize: TextFieldHeightSize) => {
   if (heightSize === 'small') return theme.typography.body3;
   else if (heightSize === 'medium') return theme.typography.body1;
@@ -36,6 +42,7 @@ export const S = {
 
     // 폰트 스타일
     ${({ theme, $heightSize }) => getFontSize(theme, $heightSize)}
+    color: ${({ theme }) => theme.colors.gray[900]};
 
     // 배경 및 테두리 스타일
     background-color: ${({ theme }) => theme.colors.white};
@@ -58,7 +65,7 @@ export const S = {
     &:disabled {
       background-color: ${({ theme }) => theme.colors.gray[100]};
       border: 2px solid ${({ theme }) => theme.colors.gray[200]};
-      color: ${({ theme }) => theme.colors.gray[200]};
+      color: ${({ theme }) => theme.colors.gray[400]};
       cursor: not-allowed;
     }
     &:disabled:hover {

--- a/src/components/TextField/style/index.ts
+++ b/src/components/TextField/style/index.ts
@@ -24,7 +24,7 @@ const getFontSize = (theme: Theme, heightSize: TextFieldHeightSize) => {
 export const S = {
   /** 공통 텍스트 필드 컴포넌트 스타일 */
   TextField: styled.input<TextFieldStyleProps>`
-    width: '100%';
+    width: 100%;
     height: ${({ $heightSize }) => HEIGHT[$heightSize]};
     padding: 0.8rem 1.2rem;
     display: flex;

--- a/src/components/TextField/types/index.ts
+++ b/src/components/TextField/types/index.ts
@@ -1,0 +1,2 @@
+/** 텍스트 필드의 높이 사이즈 */
+export type TextFieldHeightSize = 'small' | 'medium' | 'large';


### PR DESCRIPTION
### 이슈 번호

close #48 #49 

### 작업 내용

- 공통 텍스트 필드 컴포넌트 구현
- 공통 텍스트 에리어 컴포넌트 구현
- 구현한 각 컴포넌트의 스토리 추가
- 버튼 컴포넌트 일부 스타일 수정 및 스토리 args 값 업데이트

### 스크린샷(선택)

![image](https://github.com/user-attachments/assets/94f57988-cecb-42c3-94b4-d24c82ee2e0c)
![textarea-test](https://github.com/user-attachments/assets/5d37a63e-d2d4-482f-9281-a48dcbf13fff)
