### PR TITLE
프로젝트 에디터 페이지 외부 문서 링크 빈칸일 때 UI 구현

### DIFF
--- a/src/pages/ProjectEditor/components/DocumentTooltipList/index.tsx
+++ b/src/pages/ProjectEditor/components/DocumentTooltipList/index.tsx
@@ -1,5 +1,7 @@
-import { CatIcon, Trash2Icon } from 'lucide-react';
+import { CatIcon, LinkIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { useState } from 'react';
+
+import { LinkItem } from '@/types/project';
 
 import Button from '@/components/Button';
 import TextField from '@/components/TextField';
@@ -9,7 +11,11 @@ import { S } from '@/pages/ProjectEditor/components/DocumentTooltipList/style';
 import Modal from '@/pages/ProjectEditor/components/Modal';
 import TooltipList from '@/pages/ProjectItem/components/TooltipList';
 
-export default function DocumentTooltipList() {
+interface Props {
+  links: LinkItem[] | null;
+}
+
+export default function DocumentTooltipList({ links }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   const openDocumentLinkModal = () => setIsOpen(true);
@@ -18,9 +24,19 @@ export default function DocumentTooltipList() {
 
   return (
     <>
-      <ButtonWithIcon onClick={openDocumentLinkModal}>
+      <ButtonWithIcon size='100%' onClick={openDocumentLinkModal}>
         <S.TooltipListWrapper>
-          <TooltipList />
+          {links ? (
+            <TooltipList links={links} />
+          ) : (
+            <S.EmptyDocumentLinkContainer>
+              <S.IconContainer>
+                <LinkIcon />
+                <PlusIcon width='1.2rem' height='1.2rem' />
+              </S.IconContainer>
+              <S.AddDocumentLinkText>문서 외부 링크 추가</S.AddDocumentLinkText>
+            </S.EmptyDocumentLinkContainer>
+          )}
         </S.TooltipListWrapper>
       </ButtonWithIcon>
 

--- a/src/pages/ProjectEditor/components/DocumentTooltipList/style/index.ts
+++ b/src/pages/ProjectEditor/components/DocumentTooltipList/style/index.ts
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 export const S = {
   TooltipListWrapper: styled.div({
+    width: '100%',
+
     padding: '1.2rem 0.8rem',
   }),
 
@@ -19,4 +21,23 @@ export const S = {
     flexDirection: 'column',
     gap: '0.8rem',
   }),
+
+  EmptyDocumentLinkContainer: styled.div({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '3.2rem',
+    gap: '0.8rem',
+  }),
+
+  IconContainer: styled.div({
+    display: 'flex',
+    alignItems: 'start',
+  }),
+
+  AddDocumentLinkText: styled.p(({ theme }) => ({
+    color: theme.colors.gray[500],
+    ...theme.typography.body1,
+  })),
 };

--- a/src/pages/ProjectEditor/index.tsx
+++ b/src/pages/ProjectEditor/index.tsx
@@ -14,12 +14,12 @@ import ProjectSideContainer from '@/components/ProjectSideContainer';
 import CancelButton from '@/pages/ProjectEditor/components/CancelButton';
 import DeleteButton from '@/pages/ProjectEditor/components/DeleteButton';
 import DescriptionEditor from '@/pages/ProjectEditor/components/DescriptionEditor';
-// import DocumentTooltipList from '@/pages/ProjectEditor/components/DocumentTooltipList';
+import DocumentTooltipList from '@/pages/ProjectEditor/components/DocumentTooltipList';
 import EnvEditor from '@/pages/ProjectEditor/components/EnvEditor';
 import SaveButton from '@/pages/ProjectEditor/components/SaveButton';
 import TechStackEditor from '@/pages/ProjectEditor/components/TechStackEditor';
 import TitleEditor from '@/pages/ProjectEditor/components/TitleEditor';
-import styled from '@emotion/styled';
+import { S } from '@/pages/ProjectEditor/style';
 
 export default function ProjectEditor() {
   const { projectId } = useParams();
@@ -64,7 +64,7 @@ export default function ProjectEditor() {
         </Content>
         <Aside>
           <ProjectSideContainer>
-            {/* <DocumentTooltipList /> */}
+            <DocumentTooltipList links={projectId ? metadata.link : null} />
 
             <Divider />
 
@@ -81,10 +81,3 @@ export default function ProjectEditor() {
     </>
   );
 }
-
-const S = {
-  Form: styled.form({
-    display: 'flex',
-    width: '100%',
-  }),
-};

--- a/src/pages/ProjectEditor/style/index.ts
+++ b/src/pages/ProjectEditor/style/index.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const S = {
+  Form: styled.form({
+    display: 'flex',
+    width: '100%',
+  }),
+};


### PR DESCRIPTION
### 이슈 번호

close #92 

### 작업 내용

- 프로젝트 에디터 페이지 외부 문서 링크 빈칸일 때 UI 구현

### 스크린샷(선택)

### 리뷰 요구사항(선택)
