### PR TITLE
일일점검 관련 컴포넌트에 로딩 컴포넌트 추가

### DIFF
--- a/src/pages/DailyCheck/components/Loading/index.tsx
+++ b/src/pages/DailyCheck/components/Loading/index.tsx
@@ -1,0 +1,14 @@
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+import { S } from './style';
+
+/**
+ * 로딩 컴포넌트
+ */
+export default function Loading() {
+  return (
+    <S.Wrapper>
+      <LoadingSpinner size='large' />;
+    </S.Wrapper>
+  );
+}

--- a/src/pages/DailyCheck/components/Loading/style/index.ts
+++ b/src/pages/DailyCheck/components/Loading/style/index.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+/** 로딩 컴포넌트 스타일 */
+export const S = {
+  Wrapper: styled.div`
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  `,
+};

--- a/src/pages/DailyCheck/index.tsx
+++ b/src/pages/DailyCheck/index.tsx
@@ -6,6 +6,7 @@ import { SHEET_CONFIG } from '@/apis/dailyCheck/constant';
 import Aside from '@/components/Aside';
 import Content from '@/components/Content';
 
+import Loading from './components/Loading';
 import MainContent from './components/MainContent';
 import SideContent from './components/SideContent';
 import { useCurrSheetStore } from './store';
@@ -27,8 +28,7 @@ export default function DailyCheck() {
           <S.SheetTitle>{SHEET_CONFIG[currSheet].title} </S.SheetTitle>
           일일점검
         </S.PageTitle>
-        {/* TODO(지애) : 로딩 컴포넌트 */}
-        <Suspense fallback={'loading...'}>
+        <Suspense fallback={<Loading />}>
           <MainContent dailyCheckPromise={dailyCheckPromise} userName={userName} />
         </Suspense>
       </Content>

--- a/src/pages/DailyCheck/index.tsx
+++ b/src/pages/DailyCheck/index.tsx
@@ -12,8 +12,8 @@ import { useCurrSheetStore } from './store';
 import { S } from './style';
 
 //TODO(지애) : 임시 데이터
-// const userName = '이강욱'; //데이터가 있을 때
-const userName = '전증훈'; //데이터가 없을 때
+const userName = '김지애'; //데이터가 있을 때
+// const userName = '전증훈'; //데이터가 없을 때
 
 /** 일일점검 페이지 */
 export default function DailyCheck() {

--- a/src/pages/Main/components/DailyCheck/Loading.tsx
+++ b/src/pages/Main/components/DailyCheck/Loading.tsx
@@ -1,0 +1,14 @@
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+import { S } from './style';
+
+/**
+ * 로딩 중 컴포넌트
+ */
+export default function Loading() {
+  return (
+    <S.EmptyContentWrapper>
+      <LoadingSpinner size='small' />
+    </S.EmptyContentWrapper>
+  );
+}

--- a/src/pages/Main/components/DailyCheck/index.tsx
+++ b/src/pages/Main/components/DailyCheck/index.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { getTodayCheck } from '@/apis/dailyCheck';
 
 import ItemsWrapper from './ItemsWrapper';
+import Loading from './Loading';
 import { S } from './style';
 
 //TODO(지애) : 임시 데이터 수정
@@ -17,7 +18,7 @@ export default function DailyCheck() {
   return (
     <S.Container>
       <S.Title>일일점검</S.Title>
-      <Suspense fallback={<div>'...로딩중이라고'</div>}>
+      <Suspense fallback={<Loading />}>
         <ItemsWrapper todayCheckPromise={TodayCheckPromise} />
       </Suspense>
     </S.Container>

--- a/src/pages/Main/components/DailyCheck/style/index.ts
+++ b/src/pages/Main/components/DailyCheck/style/index.ts
@@ -55,8 +55,8 @@ export const S = {
     width: 18.4rem;
     height: 32rem;
     display: flex;
-    item-align: center;
-    text-align: center;
+    align-items: center;
     justify-content: center;
+    text-align: center;
   `,
 };


### PR DESCRIPTION
### 이슈 번호

close #102 

### 작업 내용
- 메인페이지 내 일일점검 컴포넌트에 로딩 컴포넌트 추가
- 일일점검 페이지에 로딩 컴포넌트 추가
- 일일점검 데이터가 있는 userName으로 수정

### 스크린샷(선택)

### 리뷰 요구사항(선택)
