### PR TITLE
버튼 그룹 및 모달 버그 수정

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -2,8 +2,11 @@ import { S } from './style';
 import type { AvatarSize } from './types';
 
 interface Props {
+  /** 아바타 이미지 URL */
   src?: string;
+  /** 아바타의 크기 */
   size?: AvatarSize;
+  /** 클릭 이벤트 핸들러 */
   onClick?: () => void;
 }
 

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -4,7 +4,9 @@ import { S } from './style';
 import type { BadgeColor, BadgeSize } from './types';
 
 interface Props extends PropsWithChildren {
+  /** 뱃지의 크기 */
   size?: BadgeSize;
+  /** 뱃지의 색상 */
   color?: BadgeColor;
 }
 

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,9 +4,13 @@ import { S } from './style';
 import type { ButtonColor, ButtonSize, ButtonVariant } from './types';
 
 interface Props extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
+  /** 버튼의 모양 */
   variant?: ButtonVariant;
+  /** 버튼의 크기 (높이는 전부 `32px`) */
   size?: ButtonSize;
+  /** 버튼의 색상 */
   color?: ButtonColor;
+  /** 로딩 중인지 여부 */
   isLoading?: boolean;
 }
 

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -43,7 +43,7 @@ export default function ButtonGroup({ items, onChange, ...p }: Props) {
 
   return (
     <S.ButtonGroupContainer ref={buttonGroupRef}>
-      <S.ButtonBackground $color={checkedItem.color} $offsetX={maxItemWidth * items.indexOf(checkedItem)} />
+      <S.ButtonBackground $color={checkedItem.color} $offsetX={maxItemWidth * items.findIndex((item) => item.value === checkedItem.value)} />
       {items.map((item) => (
         <S.Label key={item.value} $color={item.color} $checked={checkedItem.value === item.value}>
           <S.ActualRadioButton {...p} type='radio' onChange={() => handleChange(item)} name='button-group' />

--- a/src/components/ButtonGroup/style/index.ts
+++ b/src/components/ButtonGroup/style/index.ts
@@ -33,6 +33,7 @@ export const S = {
     height: 2.4rem;
     border-radius: 2.4rem;
     z-index: 1;
+    word-break: keep-all;
     cursor: pointer;
     transition: all 0.15s;
 

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, InputHTMLAttributes, PropsWithChildren } from 'react';
 import { S } from './style';
 
 interface Props extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
+  /** 체크박스 `checked` 상태(`true`/`false`)가 바뀌었을 때 호출되는 함수 */
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 

--- a/src/components/EmptyContent/index.tsx
+++ b/src/components/EmptyContent/index.tsx
@@ -4,6 +4,7 @@ import { S } from './style';
 import type { EmptyContentSize } from './types';
 
 interface Props extends PropsWithChildren {
+  /** 빈 내용 영역의 크기 */
   size?: EmptyContentSize;
 }
 

--- a/src/components/LoadingSpinner/index.tsx
+++ b/src/components/LoadingSpinner/index.tsx
@@ -2,6 +2,7 @@ import { S } from './style';
 import type { LoadingSpinnerSize } from './types';
 
 interface Props {
+  /** 로딩 스피너의 크기 */
   size?: LoadingSpinnerSize;
 }
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -8,11 +8,18 @@ import type { ModalProps } from './types';
 /**
  * 공통 모달 컴포넌트
  */
-export default function Modal({ title, subtitle, onConfirm, children }: ModalProps) {
-  const { isOpened, onCloseModal } = useModalStore();
+export default function Modal({ id, title, subtitle, onConfirm, onCancel, children }: ModalProps) {
+  const { modalState, onCloseModal } = useModalStore();
+
+  /** 모달 열림 여부 */
+  const isOpened = modalState.isOpened && modalState.id === id;
 
   const handleConfirm = () => {
     onConfirm?.();
+    onCloseModal();
+  };
+  const handleCancel = () => {
+    onCancel?.();
     onCloseModal();
   };
 
@@ -37,9 +44,11 @@ export default function Modal({ title, subtitle, onConfirm, children }: ModalPro
               확인
             </Button>
           )}
-          <Button size='medium' onClick={onCloseModal}>
-            취소
-          </Button>
+          {onCancel && (
+            <Button size='medium' onClick={handleCancel}>
+              취소
+            </Button>
+          )}
         </S.Footer>
       </S.ModalContainer>
     </S.Overlay>,

--- a/src/components/Modal/store/index.ts
+++ b/src/components/Modal/store/index.ts
@@ -1,18 +1,26 @@
 import { create } from 'zustand';
 
-/** 모달 Zustand 스토어 인터페이스 */
-interface ModalContextState {
+/** ID에 따른 모달 고유의 상태 인터페이스 */
+interface ModalState {
+  /** 모달 ID */
+  id: string | null;
   /** 모달 열림 여부 */
   isOpened: boolean;
+}
+
+/** 모달 Zustand 스토어 인터페이스 */
+interface ModalContextState {
+  /** 모달 고유 상태 */
+  modalState: ModalState;
   /** 모달을 여는 함수 */
-  onOpenModal: () => void;
+  onOpenModal: (id: string) => void;
   /** 모달을 닫는 함수 */
   onCloseModal: () => void;
 }
 
 /** 모달 Zustand 스토어 */
 export const useModalStore = create<ModalContextState>((set) => ({
-  isOpened: false,
-  onOpenModal: () => set({ isOpened: true }),
-  onCloseModal: () => set({ isOpened: false }),
+  modalState: { id: null, isOpened: false },
+  onOpenModal: (id) => set({ modalState: { id, isOpened: true } }),
+  onCloseModal: () => set({ modalState: { id: null, isOpened: false } }),
 }));

--- a/src/components/Modal/stories/Modal.stories.tsx
+++ b/src/components/Modal/stories/Modal.stories.tsx
@@ -12,13 +12,13 @@ import { ModalProps } from '../types';
  *
  * (Zustand 스토어를 사용하는 컴포넌트를 만들어서 테스트)
  */
-function ModalWithHooks({ title, subtitle, onConfirm, onCancel, children }: ModalProps) {
+function ModalWithHooks({ id, title, subtitle, onConfirm, onCancel, children }: ModalProps) {
   const { onOpenModal } = useModalStore();
 
   return (
     <>
-      <Button onClick={() => onOpenModal('test')}>Open Modal</Button>
-      <Modal id='test' title={title} subtitle={subtitle} onConfirm={onConfirm} onCancel={onCancel}>
+      <Button onClick={() => onOpenModal(id)}>Open Modal</Button>
+      <Modal id={id} title={title} subtitle={subtitle} onConfirm={onConfirm} onCancel={onCancel}>
         {children}
       </Modal>
     </>
@@ -29,7 +29,7 @@ const meta = {
   title: 'Modal',
   component: ModalWithHooks,
   tags: ['autodocs', '!dev'],
-  args: { title: 'Title', subtitle: 'Subtitle', onConfirm: fn(), onCancel: fn(), children: 'Content' },
+  args: { id: 'test', title: 'Title', subtitle: 'Subtitle', onConfirm: fn(), onCancel: fn(), children: 'Content' },
 } satisfies Meta<typeof ModalWithHooks>;
 
 export default meta;
@@ -37,5 +37,5 @@ export default meta;
 type Story = StoryObj<typeof ModalWithHooks>;
 
 export const DefaultModal: Story = {
-  args: { title: 'Title', subtitle: 'Subtitle', children: 'Content' },
+  args: { id: 'test', title: 'Title', subtitle: 'Subtitle', children: 'Content' },
 };

--- a/src/components/Modal/stories/Modal.stories.tsx
+++ b/src/components/Modal/stories/Modal.stories.tsx
@@ -12,13 +12,13 @@ import { ModalProps } from '../types';
  *
  * (Zustand 스토어를 사용하는 컴포넌트를 만들어서 테스트)
  */
-function ModalWithHooks({ title, subtitle, onConfirm, children }: ModalProps) {
+function ModalWithHooks({ title, subtitle, onConfirm, onCancel, children }: ModalProps) {
   const { onOpenModal } = useModalStore();
 
   return (
     <>
-      <Button onClick={onOpenModal}>Open Modal</Button>
-      <Modal title={title} subtitle={subtitle} onConfirm={onConfirm}>
+      <Button onClick={() => onOpenModal('test')}>Open Modal</Button>
+      <Modal id='test' title={title} subtitle={subtitle} onConfirm={onConfirm} onCancel={onCancel}>
         {children}
       </Modal>
     </>
@@ -29,7 +29,7 @@ const meta = {
   title: 'Modal',
   component: ModalWithHooks,
   tags: ['autodocs', '!dev'],
-  args: { title: 'Title', subtitle: 'Subtitle', onConfirm: fn(), children: 'Content' },
+  args: { title: 'Title', subtitle: 'Subtitle', onConfirm: fn(), onCancel: fn(), children: 'Content' },
 } satisfies Meta<typeof ModalWithHooks>;
 
 export default meta;
@@ -37,5 +37,5 @@ export default meta;
 type Story = StoryObj<typeof ModalWithHooks>;
 
 export const DefaultModal: Story = {
-  args: { title: 'Title', subtitle: 'Subtitle', onConfirm: fn(), children: 'Content' },
+  args: { title: 'Title', subtitle: 'Subtitle', children: 'Content' },
 };

--- a/src/components/Modal/types/index.ts
+++ b/src/components/Modal/types/index.ts
@@ -4,10 +4,14 @@ import { PropsWithChildren } from 'react';
  * 공통 모달 컴포넌트의 Props 인터페이스 (스토리에서도 사용하기 위해 분리)
  */
 export interface ModalProps extends PropsWithChildren {
+  /** 모달 ID (각 모달을 구분하는 문자열) */
+  id: string;
   /** 모달 제목 */
   title: string;
   /** 모달 부제목 */
   subtitle?: string;
   /** 모달 확인 버튼 클릭 이벤트 핸들러 */
   onConfirm?: () => void;
+  /** 모달 취소 버튼 클릭 이벤트 핸들러 (우측 상단 X 버튼과 별개의 버튼) */
+  onCancel?: () => void;
 }

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, TextareaHTMLAttributes } from 'react';
 import { S } from './style';
 
 interface Props extends PropsWithChildren<TextareaHTMLAttributes<HTMLTextAreaElement>> {
+  /** 입력 내용에 에러가 있는지 여부 */
   isError?: boolean;
 }
 

--- a/src/components/TextButton/index.tsx
+++ b/src/components/TextButton/index.tsx
@@ -4,7 +4,9 @@ import { S } from './style';
 import type { TextButtonColor, TextButtonSize } from './types';
 
 interface Props extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
+  /** 텍스트 버튼의 색상 */
   color?: TextButtonColor;
+  /** 텍스트 버튼의 크기 */
   size?: TextButtonSize;
 }
 

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -4,7 +4,9 @@ import { S } from './style';
 import type { TextFieldHeightSize } from './types';
 
 interface Props extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
+  /** 텍스트 필드의 높이 크기 */
   heightSize?: TextFieldHeightSize;
+  /** 입력 내용에 에러가 있는지 여부 */
   isError?: boolean;
 }
 

--- a/src/components/ToggleSwitch/index.tsx
+++ b/src/components/ToggleSwitch/index.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, InputHTMLAttributes, PropsWithChildren } from 'react';
 import { S } from './style';
 
 interface Props extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
+  /** 토글 스위치의 `checked` 상태(`true`/`false`)가 바뀌었을 때 호출되는 함수 */
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 


### PR DESCRIPTION
### 이슈 번호

close #125 

### 작업 내용

- 버튼 그룹에서 특정 텍스트가 두 줄로 나타나는 문제 수정
  - ex: `서비스`, `개발` 두 개의 아이템을 넣으면 `서비스`가 `서비`/`스`로 개행되어 표시
  - 버튼 그룹 내 버튼 레이블 텍스트를 개행되지 않도록 스타일 수정
- 컴포넌트 안에 모달 컴포넌트가 두 개 이상일 경우, 하나의 모달을 열면 다른 모달도 강제로 열리는 버그 수정
  - 모달에 ID 값을 부여, 열림 상태를 ID별로 처리하도록 Zustand 스토어 업데이트