### PR TITLE
refactor: 프로젝트 페이지 전체적인 디자인 시안에 맞게 수정

### DIFF
--- a/src/components/DateText/index.tsx
+++ b/src/components/DateText/index.tsx
@@ -1,0 +1,12 @@
+import { S } from '@/components/DateText/style';
+import { Size } from '@/components/DateText/types';
+
+interface Props {
+  startDate: string;
+  endDate: string;
+  size?: Size;
+}
+
+export default function DateText({ startDate, endDate, size = 'large' }: Props) {
+  return /\d/.test(startDate) && /\d/.test(endDate) && <S.DateText $size={size}>{`${startDate} ~ ${endDate}`}</S.DateText>;
+}

--- a/src/components/DateText/style/index.ts
+++ b/src/components/DateText/style/index.ts
@@ -1,0 +1,21 @@
+import { Size } from '@/components/DateText/types';
+
+import { Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const generateTypography = (size: Size, theme: Theme) => {
+  switch (size) {
+    case 'small':
+      return theme.typography.body3;
+    case 'large':
+      return theme.typography.body1;
+  }
+};
+
+export const S = {
+  DateText: styled.p<{ $size: Size }>`
+    color: ${({ theme }) => theme.colors.gray[500]};
+
+    ${({ theme, $size }) => generateTypography($size, theme)}
+  `,
+};

--- a/src/components/DateText/types/index.ts
+++ b/src/components/DateText/types/index.ts
@@ -1,0 +1,1 @@
+export type Size = 'small' | 'large';

--- a/src/components/TechStack/index.tsx
+++ b/src/components/TechStack/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, RefObject } from 'react';
 
 import { TechStackItem } from '@/types/project';
 
@@ -6,6 +6,7 @@ import DraggableScroller from '@/components/DraggableScroll';
 import { S } from '@/components/TechStack/style';
 
 interface Props {
+  ref?: RefObject<HTMLUListElement | null>;
   techStacks?: TechStackItem | null;
   display?: 'flex' | 'grid';
 }
@@ -18,11 +19,11 @@ function Title({ children }: PropsWithChildren) {
   return <S.PositionTitle>{children}</S.PositionTitle>;
 }
 
-function List({ techStacks, display = 'flex' }: Props) {
+function List({ ref, techStacks, display = 'flex' }: Props) {
   return (
     <>
       {display === 'flex' ? (
-        <S.TechStackImgFlexList>
+        <S.TechStackImgFlexList ref={ref}>
           <DraggableScroller>
             {techStacks?.map(({ url, tag }) => {
               return (

--- a/src/pages/ProjectItem/components/Description/hooks/index.ts
+++ b/src/pages/ProjectItem/components/Description/hooks/index.ts
@@ -1,0 +1,24 @@
+import { RefObject, useEffect, useState } from 'react';
+
+interface Props {
+  ref: RefObject<HTMLParagraphElement | null>;
+  description: string;
+}
+
+export const useIsMoreButtonVisible = ({ ref, description }: Props) => {
+  const [isMoreButtonVisible, setIsMoreButtonVisible] = useState(false);
+
+  useEffect(() => {
+    if (ref.current) {
+      const element = ref.current;
+      const lineHeight = parseFloat(window.getComputedStyle(element).lineHeight || '1.5');
+      const maxHeight = lineHeight * 6; // 6줄 기준 높이 계산
+
+      if (element.scrollHeight > maxHeight) {
+        setIsMoreButtonVisible(true);
+      }
+    }
+  }, [ref, description]);
+
+  return isMoreButtonVisible;
+};

--- a/src/pages/ProjectItem/components/Description/index.tsx
+++ b/src/pages/ProjectItem/components/Description/index.tsx
@@ -3,6 +3,7 @@ import { RefObject, useState } from 'react';
 import DescriptionContainer from '@/components/DescriptionContainer';
 import MoreButton from '@/components/MoreButton';
 
+import { useIsMoreButtonVisible } from '@/pages/ProjectItem/components/Description/hooks';
 import { S } from '@/pages/ProjectItem/components/Description/style';
 
 interface Props {
@@ -10,16 +11,18 @@ interface Props {
   description: string;
 }
 
-// TODO(증훈): 서버 데이터로 교체
-export default function Description({ ref, description }: Props) {
+export default function Description({ description, ref }: Props) {
   const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
+  const isMoreButtonVisible = useIsMoreButtonVisible({ ref, description });
 
   const handleToggleDescription = () => setIsDescriptionOpen(!isDescriptionOpen);
 
   return (
-    <DescriptionContainer ref={ref}>
-      <S.DescriptionText $isOpen={isDescriptionOpen}>{description}</S.DescriptionText>
-      <MoreButton isOpen={isDescriptionOpen} onClick={handleToggleDescription} />
+    <DescriptionContainer>
+      <S.DescriptionText ref={ref} $isOpen={isDescriptionOpen}>
+        {description}
+      </S.DescriptionText>
+      {isMoreButtonVisible && <MoreButton isOpen={isDescriptionOpen} onClick={handleToggleDescription} />}
     </DescriptionContainer>
   );
 }

--- a/src/pages/ProjectItem/components/TableOfContent/index.tsx
+++ b/src/pages/ProjectItem/components/TableOfContent/index.tsx
@@ -12,9 +12,10 @@ interface Props {
   linkRef: RefObject<HTMLUListElement | null>;
   descriptionRef: RefObject<HTMLHeadingElement | null>;
   techStackRef: RefObject<HTMLHeadingElement | null>;
+  hasTechStackContent: boolean;
 }
 
-export default function TableOfContent({ linkRef, descriptionRef, techStackRef }: Props) {
+export default function TableOfContent({ linkRef, descriptionRef, techStackRef, hasTechStackContent }: Props) {
   const [focusedScroll, setFocusedScroll] = useState<FocusedScroll>({
     link: true,
     description: false,
@@ -43,9 +44,11 @@ export default function TableOfContent({ linkRef, descriptionRef, techStackRef }
         <S.TableOfContentButton onClick={() => handleScrollTo(descriptionRef, 'description')}>
           <S.TableOfContentText $isFocus={focusedScroll.description}>프로젝트 설명</S.TableOfContentText>
         </S.TableOfContentButton>
-        <S.TableOfContentButton onClick={() => handleScrollTo(techStackRef, 'techStack')}>
-          <S.TableOfContentText $isFocus={focusedScroll.techStack}>기술 스택</S.TableOfContentText>
-        </S.TableOfContentButton>
+        {hasTechStackContent && (
+          <S.TableOfContentButton onClick={() => handleScrollTo(techStackRef, 'techStack')}>
+            <S.TableOfContentText $isFocus={focusedScroll.techStack}>기술 스택</S.TableOfContentText>
+          </S.TableOfContentButton>
+        )}
       </S.TableOfContentContainer>
     </S.TableContainer>
   );

--- a/src/pages/ProjectItem/components/TechStack/index.tsx
+++ b/src/pages/ProjectItem/components/TechStack/index.tsx
@@ -17,6 +17,8 @@ export default function TechStack({ ref, frontend, backend }: Props) {
 
   const handleToggleTechStack = () => setIsTechStackOpen(!isTechStackOpen);
 
+  if (!frontend && !backend) return null;
+
   return (
     <TechStackContainer ref={ref}>
       <TechStackWithPosition>

--- a/src/pages/ProjectItem/components/Title/index.tsx
+++ b/src/pages/ProjectItem/components/Title/index.tsx
@@ -6,6 +6,7 @@ import { BADGE_STATUS, STATUS_TEXT } from '@/constants/common';
 
 import Avatar from '@/components/Avatar';
 import Badge from '@/components/Badge';
+import DateText from '@/components/DateText';
 import Divider from '@/components/Divider';
 import ProjectThumbnail from '@/components/ProjectThumbnail';
 
@@ -48,7 +49,7 @@ export default function Title({ thumbnailImageUrl, title, status, startDate, end
             </S.AvatarContainer>
             {Boolean(parsedMembers.length) && <S.MemberCountText>{parsedMembers.length}명</S.MemberCountText>}
           </S.MemberInfoContainer>
-          {/\d/.test(startDate) && /\d/.test(endDate) && <S.DateText>{`${startDate} ~ ${endDate}`}</S.DateText>}
+          <DateText startDate={startDate} endDate={endDate} />
         </S.MemberAndDateContainer>
       </S.RightContainer>
     </S.Container>

--- a/src/pages/ProjectItem/index.tsx
+++ b/src/pages/ProjectItem/index.tsx
@@ -38,7 +38,12 @@ export default function ProjectItem() {
           <TooltipList ref={linkRef} links={links} />
           <EditorLink />
           <Divider />
-          <TableOfContent linkRef={linkRef} descriptionRef={descriptionRef} techStackRef={techStackRef} />
+          <TableOfContent
+            linkRef={linkRef}
+            descriptionRef={descriptionRef}
+            techStackRef={techStackRef}
+            hasTechStackContent={Boolean(frontend || backend)}
+          />
         </ProjectSideContainer>
       </Aside>
     </>

--- a/src/pages/ProjectList/components/ProjectCard/index.tsx
+++ b/src/pages/ProjectList/components/ProjectCard/index.tsx
@@ -3,6 +3,7 @@ import { Status } from '@/types/project';
 import { BADGE_STATUS, STATUS_TEXT } from '@/constants/common';
 
 import Badge from '@/components/Badge';
+import DateText from '@/components/DateText';
 import ProjectThumbnail from '@/components/ProjectThumbnail';
 
 import { S } from '@/pages/ProjectList/components/ProjectCard/style';
@@ -22,12 +23,10 @@ export default function ProjectCard({ title, thumbnailImageUrl, startDate, endDa
       <S.Title>{title}</S.Title>
       <ProjectThumbnail src={thumbnailImageUrl} alt={`${title} 썸네일`} size='large' />
       <S.ContentContainer>
-        <S.DateContainer>
-          <S.DateText>{startDate}</S.DateText>
-          <S.DateText>~</S.DateText>
-          <S.DateText>{endDate}</S.DateText>
-        </S.DateContainer>
-        <Badge color={BADGE_STATUS[status]}>{STATUS_TEXT[status]}</Badge>
+        <DateText startDate={startDate} endDate={endDate} size='small' />
+        <S.BadgeContainer>
+          <Badge color={BADGE_STATUS[status]}>{STATUS_TEXT[status]}</Badge>
+        </S.BadgeContainer>
       </S.ContentContainer>
       <S.Description>{description}</S.Description>
     </S.Container>

--- a/src/pages/ProjectList/components/ProjectCard/style/index.ts
+++ b/src/pages/ProjectList/components/ProjectCard/style/index.ts
@@ -24,6 +24,12 @@ export const S = {
   `,
 
   Title: styled.h2(({ theme }) => ({
+    display: '-webkit-box',
+
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    WebkitLineClamp: 1,
+
     color: theme.colors.gray[800],
     ...theme.typography.subtitle,
   })),
@@ -40,22 +46,19 @@ export const S = {
   ContentContainer: styled.div({
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
 
     width: '100%',
   }),
 
-  DateContainer: styled.div({
-    display: 'flex',
-    gap: '0.4rem',
+  BadgeContainer: styled.div({
+    marginLeft: 'auto', // Badge를 항상 오른쪽 끝으로 이동
   }),
-
-  DateText: styled.p(({ theme }) => ({
-    color: theme.colors.gray[500],
-    ...theme.typography.body3,
-  })),
 
   Description: styled.p(({ theme }) => ({
     display: '-webkit-box',
+
+    flex: 1,
 
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',


### PR DESCRIPTION
### 이슈 번호

close #168 

### 작업 내용

- 프로젝트 카드 레이아웃 수정
- 프로젝트 아이템 페이지의 설명 더보기 필요없을 경우 렌더링하지 않도록 수정
- 프로젝트 기술스택 없을 경우 렌더링하지 않도록 수정
- 기술스택 없을 경우 목차에 렌더링하지 않도록 수정
- 제대로된 날짜가 아닐 경우 프로젝트 카드와 아이템 페이지에서 렌더링하지 않도록 수정

### 스크린샷(선택)

### 리뷰 요구사항(선택)
